### PR TITLE
Add crypto data ingestion and CLI date args

### DIFF
--- a/DataPipeline/crypto.py
+++ b/DataPipeline/crypto.py
@@ -1,0 +1,27 @@
+import time
+from datetime import datetime
+from typing import List
+
+import ccxt
+import pandas as pd
+
+
+def fetch_crypto(symbol: str) -> pd.DataFrame:
+    """Fetch daily OHLCV for a crypto symbol using ccxt (Binance)."""
+    exchange = ccxt.binance()
+    all_rows: List[List] = []
+    since = None
+    while True:
+        data = exchange.fetch_ohlcv(symbol, timeframe="1d", since=since, limit=1000)
+        if not data:
+            break
+        all_rows.extend(data)
+        since = data[-1][0] + 24 * 60 * 60 * 1000
+        if len(data) < 1000:
+            break
+        time.sleep(exchange.rateLimit / 1000)
+
+    df = pd.DataFrame(all_rows, columns=["Date", "Open", "High", "Low", "Close", "Volume"])
+    df["Date"] = pd.to_datetime(df["Date"], unit="ms")
+    df.set_index("Date", inplace=True)
+    return df

--- a/DataPipeline/requirements.txt
+++ b/DataPipeline/requirements.txt
@@ -1,3 +1,5 @@
 pandas
 SQLAlchemy
+yfinance
+ccxt
 python-dotenv

--- a/Readme.md
+++ b/Readme.md
@@ -98,8 +98,9 @@ README.md                   # This file
 
 ### Purpose
 
-* Downloads OHLCV data for specified symbols via the `yfinance` library.
-* Filters by a date range (e.g., `2022-01-01` through today).
+* Downloads equity OHLCV via the `yfinance` library.
+* Downloads crypto OHLCV via `ccxt` (Binance).
+* Filters by a start/end date range.
 * Strips timezone info and writes the filtered DataFrame to SQLite tables in `market_data.db`.
 
 ### How to Run
@@ -110,11 +111,11 @@ README.md                   # This file
    source .venv/bin/activate
    ```
 2. (Optional) Inspect or edit `DataPipeline/.env` to set `DB_PATH` (default: `market_data.db`).
-3. Run the pipeline script:
+3. Run the pipeline script (optionally pass `--start` and `--end` in `YYYY-MM-DD` format):
 
    ```bash
    cd DataPipeline
-   python pipeline.py
+   python pipeline.py --start 2020-01-01 --end 2023-01-01
    ```
 4. Confirm the database:
 


### PR DESCRIPTION
## Summary
- add ccxt-based crypto downloader
- parse --start and --end arguments in data pipeline
- store crypto data in tables like `CRYPTO_BTCUSDT`
- document new usage and dependencies

## Testing
- `python3 -m py_compile DataPipeline/*.py`
- `pip install -q -r DataPipeline/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68477a9e5d78832abf1cd3a7904b5c0d