### PR TITLE
Fix dotenv requirement

### DIFF
--- a/Backtester/requirements.txt
+++ b/Backtester/requirements.txt
@@ -1,6 +1,7 @@
 backtrader
 pandas
 SQLAlchemy
-python=dotenv
-ib_insync          # for future live‐trading integration
-openai             # for on‐the‐fly prompt tuning (optional)
+python-dotenv
+ib_insync
+openai
+


### PR DESCRIPTION
## Summary
- replace erroneous `python=dotenv` with `python-dotenv`
- put each requirement on its own line

## Testing
- `pip install -r Backtester/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6848265848ac832aa097ed19b27e9cc6