### PR TITLE
Fix DB path handling for API

### DIFF
--- a/API/.env
+++ b/API/.env
@@ -1,4 +1,4 @@
-DB_PATH=/Users/ajs/Desktop/Coding Practice for Trading/TradingFund/DataPipeline/market_data.db
+DB_PATH=../DataPipeline/market_data.db
 # (If you’re using ib_insync for live trading later, you can store IB_HOST, IB_PORT here.)
 # IB_HOST=127.0.0.1
 # IB_PORT=7497

--- a/API/main.py
+++ b/API/main.py
@@ -10,9 +10,10 @@ from dotenv import load_dotenv
 
 load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), ".env"))
 
-DB_PATH = os.getenv("DB_PATH")
-if not DB_PATH:
+db_path_env = os.getenv("DB_PATH")
+if not db_path_env:
     raise RuntimeError("DB_PATH must be set in API/.env")
+DB_PATH = os.path.join(os.path.dirname(__file__), db_path_env)
 
 # If you prefer to read directly from JSON, skip DB querying. But for flexibility, we’ll read JSON for now.
 # In production, you might read the DB’s PnL table directly.


### PR DESCRIPTION
## Summary
- make `DB_PATH` in `API/.env` relative to the repo
- resolve the path in `API/main.py`

## Testing
- `CI=true npm test --prefix dashboard` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848265ca978832a9ead8feab108c9a9