### PR TITLE
Add spread metrics endpoint

### DIFF
--- a/API/main.py
+++ b/API/main.py
@@ -28,6 +28,16 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+@app.get("/spread_metrics")
+def get_spread_metrics():
+    """Return spread backtest metrics stored in metrics_spread.json."""
+    metrics_path = os.path.join(os.path.dirname(__file__), "metrics_spread.json")
+    if not os.path.isfile(metrics_path):
+        raise HTTPException(status_code=404, detail="Spread metrics file not found")
+    with open(metrics_path, "r") as f:
+        data = json.load(f)
+    return data
+
 @app.get("/pnl", response_model=List[dict])
 def get_pnl(
     symbol: str = Query(..., description="Ticker symbol used in the backtest"),

--- a/API/metrics_spread.json
+++ b/API/metrics_spread.json
@@ -1,0 +1,4 @@
+{
+  "sharpe_ratio": 0.0,
+  "max_drawdown": 0.0
+}


### PR DESCRIPTION
## Summary
- extend API to expose `metrics_spread.json`
- add placeholder metrics JSON file

## Testing
- `pytest -q`
- `yarn test --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684aeec465a0832ab8c3b972dcf4b328