### PR TITLE
Add SeasonalPatternTable component

### DIFF
--- a/dashboard/src/components/SeasonalPatternTable.tsx
+++ b/dashboard/src/components/SeasonalPatternTable.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from "react";
+import Table from "react-bootstrap/Table";
+import { api } from "../api/client";
+
+export interface WeekStat {
+  weekday: string;
+  avg_return: number;
+  t_stat: number;
+}
+
+const SeasonalPatternTable: React.FC = () => {
+  const [stats, setStats] = useState<WeekStat[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const response = await api.get<WeekStat[]>("/seasonal_stats");
+        setStats(response.data);
+        setError(null);
+      } catch (err: any) {
+        setError(err.message ?? "Unknown error");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchStats();
+  }, []);
+
+  if (loading) {
+    return <p>Loading seasonal stats…</p>;
+  }
+  if (error) {
+    return <p style={{ color: "red" }}>Error: {error}</p>;
+  }
+
+  return (
+    <Table striped bordered hover>
+      <thead>
+        <tr>
+          <th>Weekday</th>
+          <th>Avg Return</th>
+          <th>t-Statistic</th>
+        </tr>
+      </thead>
+      <tbody>
+        {stats.map((stat) => (
+          <tr key={stat.weekday}>
+            <td>{stat.weekday}</td>
+            <td>{(stat.avg_return * 100).toFixed(2)}%</td>
+            <td>{stat.t_stat.toFixed(2)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+export default SeasonalPatternTable;


### PR DESCRIPTION
## Summary
- implement `SeasonalPatternTable` React component to display weekly return stats

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react-bootstrap/Table')*
- `CI=true npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684aeffb9710832a9d3d53a4d86cb6fc