### PR TITLE
Add new dashboard sections

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -3,6 +3,9 @@
 import React, { useEffect, useState } from "react";
 import { api } from "./api/client";
 import PnlChart from "./components/PnlChart";
+import { SweepSummaryTable } from "./components/SweepSummaryTable";
+import { SeasonalPatternTable } from "./components/SeasonalPatternTable";
+import { SpreadMetricsCard } from "./components/SpreadMetricsCard";
 
 interface PnlPoint {
   date: string;
@@ -67,6 +70,18 @@ function App() {
       {!loading && !error && pnlData.length === 0 && (
         <p>No P&amp;L data available.</p>
       )}
+      <section>
+        <h2>Parameter Sweep Summary</h2>
+        <SweepSummaryTable />
+      </section>
+      <section>
+        <h2>Seasonal Patterns</h2>
+        <SeasonalPatternTable />
+      </section>
+      <section>
+        <h2>BTC–ETH Spread Metrics</h2>
+        <SpreadMetricsCard />
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show sweep summary, seasonal patterns, and spread metrics in dashboard

## Testing
- `npm test --silent --maxWorkers=2` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684af17c098c832a8378f2986d937439