### PR TITLE
Export seasonal stats JSON

### DIFF
--- a/Backtester/seasonal_pattern_scan.py
+++ b/Backtester/seasonal_pattern_scan.py
@@ -52,6 +52,19 @@ def main() -> None:
 
     print(result.to_string(float_format=lambda x: f"{x: .6f}"))
 
+    results_list = [
+        {
+            "weekday": idx,
+            "avg_return": row["average_return"],
+            "t_stat": row["t_stat"],
+        }
+        for idx, row in result.iterrows()
+    ]
+
+    with open("../API/seasonal_stats.json", "w") as f:
+        json.dump(results_list, f, indent=2)
+    print("Wrote ../API/seasonal_stats.json")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- compute weekday stats list in `seasonal_pattern_scan.py`
- write the list to `../API/seasonal_stats.json` with indentation
- print confirmation message when file is written

## Testing
- `python -m py_compile Backtester/seasonal_pattern_scan.py`

------
https://chatgpt.com/codex/tasks/task_e_684af609fff8832a8f82c6ab30ccd971