### PR TITLE
Fix NaN handling in sweep summary endpoint

### DIFF
--- a/API/main.py
+++ b/API/main.py
@@ -78,8 +78,8 @@ def sweep_summary():
         raise HTTPException(status_code=404, detail="sweep_summary.csv not found")
     df = pd.read_csv(csv_path)
 
-    # Replace NaN with None so JSON is valid
-    df = df.where(pd.notnull(df), None)
+    # Convert to object dtype first so None values are preserved
+    df = df.astype(object).where(pd.notnull(df), None)
 
     return JSONResponse(content=df.to_dict(orient="records"))
 


### PR DESCRIPTION
## Summary
- preserve `None` when reading `sweep_summary.csv` so JSON serialization succeeds

## Testing
- `python3 -m py_compile API/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541611955c832ab3f23d29d8cae22f