### PR TITLE
Update sweep_to_csv PnL sweep summary script

### DIFF
--- a/Backtester/sweep_to_csv.py
+++ b/Backtester/sweep_to_csv.py
@@ -1,44 +1,30 @@
-import os
-import json
-import pandas as pd
+# Backtester/sweep_to_csv.py
+import json, pathlib, pandas as pd, numpy as np, os
 
+root   = pathlib.Path(__file__).parents[1]
+cfg    = json.load(open(root / "config.json"))
+symbol = cfg["symbol"]
 
-def load_sweep_results(sweep_dir: str) -> pd.DataFrame:
-    """Load all JSON P&L files from sweep_dir and return summary DataFrame."""
-    records = []
-    for fname in os.listdir(sweep_dir):
-        if not fname.endswith('.json'):
-            continue
-        path = os.path.join(sweep_dir, fname)
-        with open(path, 'r') as f:
-            data = json.load(f)
-        # parse parameters from filename: pnl_{period}_{devfactor}_{stake}.json
-        base = os.path.splitext(fname)[0]
-        try:
-            _, period, devfactor, stake = base.split('_')
-            period = int(period)
-            devfactor = float(devfactor)
-            stake = int(stake)
-        except ValueError:
-            # unexpected filename format
-            period = devfactor = stake = None
-        pnl = data[-1]['value'] if data else 0
-        records.append({
-            'period': period,
-            'devfactor': devfactor,
-            'stake': stake,
-            'final_pnl': pnl,
-        })
-    return pd.DataFrame(records)
+sweep_dir = root / "API" / "pnl_sweep" / symbol
+rows = []
 
+for f in sweep_dir.glob("pnl_*.json"):
+    _, period, dev, stake = f.stem.split("_")
+    pnl = pd.read_json(f)
+    ret = pd.Series(pnl["value"]).pct_change().dropna()
+    sharpe = np.sqrt(252) * ret.mean() / ret.std() if not ret.empty else np.nan
+    dd = (pd.Series(pnl["value"]) / pd.Series(pnl["value"]).cummax() - 1).min()
+    rows.append({
+        "period": int(period),
+        "devfactor": float(dev),
+        "stake": int(stake),
+        "total_return": pnl["value"].iloc[-1] / pnl["value"].iloc[0] - 1,
+        "sharpe": sharpe,
+        "max_drawdown": dd,
+        "final_pnl": pnl["value"].iloc[-1]
+    })
 
-def main() -> None:
-    sweep_dir = os.path.join(os.path.dirname(__file__), '..', 'API', 'pnl_sweep')
-    df = load_sweep_results(sweep_dir)
-    output_path = os.path.join(os.path.dirname(__file__), '..', 'API', 'sweep_summary.csv')
-    df.to_csv(output_path, index=False)
-    print("Wrote ../API/sweep_summary.csv")
+pd.DataFrame(rows).sort_values("sharpe", ascending=False) \
+  .to_csv(root / "API" / f"sweep_summary_{symbol.lower()}.csv", index=False)
 
-
-if __name__ == '__main__':
-    main()
+print("\u2713 sweep_summary written for", symbol)


### PR DESCRIPTION
## Summary
- replace Backtester/sweep_to_csv.py with version that loads config
- compute statistics and write `sweep_summary_<symbol>.csv`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685960d06e0c832a99f42a2d120da847