### PR TITLE
Fix axios imports

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -1,6 +1,6 @@
 // Dashboard/src/api/client.ts
 
-import axios from "axios/dist/node/axios.cjs";
+import axios from "axios";
 
 export const api = axios.create({
   baseURL: "http://localhost:8000", // point to our FastAPI service

--- a/dashboard/src/components/SeasonalPatternTable.tsx
+++ b/dashboard/src/components/SeasonalPatternTable.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 // Use a standard HTML table; no react-bootstrap dependency
-import axios from "axios/dist/node/axios.cjs";
+import axios from "axios";
 
 export interface WeekStat {
   weekday: string;

--- a/dashboard/src/components/SweepSummaryTable.tsx
+++ b/dashboard/src/components/SweepSummaryTable.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 // Using a regular HTML table instead of react-bootstrap to avoid external dependencies
-import axios from "axios/dist/node/axios.cjs";
+import axios from "axios";
 
 export interface SweepRow {
   period: number;


### PR DESCRIPTION
## Summary
- replace custom axios path with default import in dashboard client and components

## Testing
- `CI=true npm test --silent --maxWorkers=2` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68596bc787e8832abb16608f98cf49c4