### PR TITLE
Add Render deploy summary for dashboard

### DIFF
--- a/dashboard/RENDER_DEPLOY_SUMMARY.md
+++ b/dashboard/RENDER_DEPLOY_SUMMARY.md
@@ -1,0 +1,9 @@
+# Render Static Deploy Summary
+
+Use this summary to configure the TradingFund React dashboard as a static site on Render.
+
+- **Root Directory:** Dashboard
+- **Build Command:** `npm install && npm run build`
+- **Publish Directory:** `dist`
+- **Environment Variables:**
+  - `VITE_API_URL=https://tradingfund.onrender.com`


### PR DESCRIPTION
## Summary
- add a concise Render static-site deployment summary for the React dashboard
- document root directory, build/publish settings, and API URL environment variable

## Testing
- not run (not needed for documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69250ffaa804832ab1bb893e5a505630)